### PR TITLE
 Feature: 유저가 요청한 PDF파일을 S3에서 불러와 프론트에 전달

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -27,7 +27,7 @@ exports.signIn = async (req, res, next) => {
         maxAge: 1000 * 60 * 60 * 24,
         httpOnly: true,
       })
-      .json({ result: "success", userID: user._id });
+      .json({ result: "success", userId: user._id });
   } catch (error) {
     error.message = ERRORMESSAGE.ERROR_500;
     error.status = 500;

--- a/src/controllers/documents.controller.js
+++ b/src/controllers/documents.controller.js
@@ -1,5 +1,7 @@
 const User = require("../models/User");
 const Pdf = require("../models/Pdf");
+const { getDocumentInS3 } = require("../service/s3utils");
+const ERRORMESSAGE = require("../constants/error");
 
 exports.getAll = async (req, res, next) => {
   try {
@@ -14,9 +16,29 @@ exports.getAll = async (req, res, next) => {
       documents: userInfo.pdfDocuments,
     });
   } catch (error) {
-    error.message = "Internal Server Error";
+    error.message = ERRORMESSAGE.ERROR_500;
     error.status = 500;
 
     next(error);
+  }
+};
+
+exports.getDocument = async (req, res, next) => {
+  try {
+    const { documentTitle } = req.params;
+
+    const pdfDocument = await getDocumentInS3(documentTitle, next);
+
+    res.set({
+      "Content-Type": "application/pdf",
+      "Content-Length": pdfDocument.length,
+    });
+
+    res.send(pdfDocument);
+  } catch (error) {
+    error.message = ERRORMESSAGE.ERROR_500;
+    error.status = 500;
+
+    return next(error);
   }
 };

--- a/src/controllers/documents.controller.js
+++ b/src/controllers/documents.controller.js
@@ -25,10 +25,8 @@ exports.getAll = async (req, res, next) => {
 
 exports.getDocument = async (req, res, next) => {
   try {
-    const { documentTitle } = req.params;
-
-    const pdfDocument = await getDocumentInS3(documentTitle, next);
-
+    const { userId, documentId } = req.params;
+    const pdfDocument = await getDocumentInS3(userId, documentId, next);
     res.set({
       "Content-Type": "application/pdf",
       "Content-Length": pdfDocument.length,

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -5,9 +5,6 @@ const documentsController = require("../controllers/documents.controller");
 const router = express.Router();
 
 router.get("/:userId/documents", documentsController.getAll);
-router.get(
-  "/:userId/documents/:documentTitle",
-  documentsController.getDocument
-);
+router.get("/:userId/documents/:documentId", documentsController.getDocument);
 
 module.exports = router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -5,5 +5,9 @@ const documentsController = require("../controllers/documents.controller");
 const router = express.Router();
 
 router.get("/:userId/documents", documentsController.getAll);
+router.get(
+  "/:userId/documents/:documentTitle",
+  documentsController.getDocument
+);
 
 module.exports = router;

--- a/src/service/s3utils.js
+++ b/src/service/s3utils.js
@@ -32,15 +32,15 @@ const s3ConfigSetup = async (next) => {
   }
 };
 
-const uploadDocumentInS3 = async (documentTitle, document, next) => {
+const uploadDocumentInS3 = async (userId, documentId, document, next) => {
   try {
-    await s3ConfigSetup();
+    await s3ConfigSetup(next);
 
     const pdfUpload = new Upload({
       client: s3,
       params: {
         Bucket: CONFIG.S3_BUCKET_NAME,
-        Key: `documents/${documentTitle}.pdf`,
+        Key: `users/${userId}/documents/${documentId}.pdf`,
         Body: document,
       },
     });
@@ -58,13 +58,13 @@ const uploadDocumentInS3 = async (documentTitle, document, next) => {
   }
 };
 
-const getDocumentInS3 = async (documentTitle, next) => {
+const getDocumentInS3 = async (userId, documentId, next) => {
   try {
     await s3ConfigSetup(next);
 
     const pdfInS3 = new GetObjectCommand({
       Bucket: CONFIG.S3_BUCKET_NAME,
-      Key: `documents-${documentTitle}.pdf`,
+      Key: `users/${userId}/documents/${documentId}.pdf`,
     });
 
     const readableStream = await s3.send(pdfInS3);

--- a/src/service/s3utils.js
+++ b/src/service/s3utils.js
@@ -2,6 +2,7 @@ const { S3, GetObjectCommand } = require("@aws-sdk/client-s3");
 const { Upload } = require("@aws-sdk/lib-storage");
 
 const CONFIG = require("../constants/config");
+const ERRORMESSAGE = require("../constants/error");
 
 const s3 = new S3({
   region: CONFIG.S3_REGION,
@@ -24,22 +25,22 @@ const s3ConfigSetup = async (next) => {
   try {
     await s3.putBucketCors(bucketParams);
   } catch (error) {
-    error.message = "Internal Server Error";
+    error.message = ERRORMESSAGE.ERROR_500;
     error.status = 500;
 
-    next(error);
+    return next(error);
   }
 };
 
-const uploadDocumentInS3 = async (documentId, document, next) => {
+const uploadDocumentInS3 = async (documentTitle, document, next) => {
   try {
-    s3ConfigSetup();
+    await s3ConfigSetup();
 
     const pdfUpload = new Upload({
       client: s3,
       params: {
         Bucket: CONFIG.S3_BUCKET_NAME,
-        Key: `documents/${documentId}.pdf`,
+        Key: `documents/${documentTitle}.pdf`,
         Body: document,
       },
     });
@@ -50,30 +51,32 @@ const uploadDocumentInS3 = async (documentId, document, next) => {
 
     await pdfUpload.done();
   } catch (error) {
-    error.message = "Internal Server Error";
+    error.message = ERRORMESSAGE.ERROR_500;
     error.status = 500;
 
-    next(error);
+    return next(error);
   }
 };
 
-const getDocumentInS3 = async (documentId, next) => {
+const getDocumentInS3 = async (documentTitle, next) => {
   try {
-    s3ConfigSetup();
+    await s3ConfigSetup(next);
 
     const pdfInS3 = new GetObjectCommand({
       Bucket: CONFIG.S3_BUCKET_NAME,
-      Key: `documents/${documentId}.pdf`,
+      Key: `documents-${documentTitle}.pdf`,
     });
 
-    const response = await s3.send(pdfInS3);
+    const readableStream = await s3.send(pdfInS3);
+    const arrayBuffer = await readableStream.Body.transformToByteArray();
+    const buffer = Buffer.from(arrayBuffer);
 
-    return response.Body;
+    return buffer;
   } catch (error) {
-    error.message = "Internal Server Error";
+    error.message = ERRORMESSAGE.ERROR_500;
     error.status = 500;
 
-    next(error);
+    return next(error);
   }
 };
 


### PR DESCRIPTION
### [response]선택한 PDF 데이터 응답

### Task

- [task card 링크](https://www.notion.so/vanillacoding/response-PDF-3cd9e0422f944b01aeaf0012cb804280?pvs=4)

### Description

```js
    const readableStream = await s3.send(pdfInS3);
    const arrayBuffer = await readableStream.Body.transformToByteArray();
    const buffer = Buffer.from(arrayBuffer);
```
- src/service/s3utils.js
  - 기존 getDocumentInS3 함수에서 s3.send(pdfInS3)의 promise가 readableStream이라는 것을 확인
  - 프론트에서 PDF 파일을 렌더링 하기 위해서는 readableStream을 buffer로 바꾸어 전달해 줄 필요가 있었으며, s3에서 제공하는 transformToByteArray메소드를 사용하여 arrayBuffer로 변환 한 후 node에서 제공하는 Buffer.from()메소드를 사용하여 buffer로 바꾸어 줌.
  
- src/controllers/documents.controller.js
  - 프론트엔드에서 요청한 유저의 PDF파일을 s3에서 받아와 프론트엔드에 응답

### Point

- readableStream & arrayBuffer & buffer에 대해 각자 공부하고, 왜 readableStream이었을 때 렌더링 되지 않았던 PDF 파일이 buffer일 때 읽을 수 있었는지, 이야기 해보면 좋을것 같습니다!
- S3의 버켓에 저장되는 정보들의 계층 구조를 반영하기 위해 "-"를 사용해 저장되는 객체들의 이름을 변경헀습니다 "/"는 일반적인 방법으로 쓰일 수 없는 듯 합니다.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html

예시)
   font-SefifText-Italic.woff2
   document-sample.pdf

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷
![image](https://user-images.githubusercontent.com/106131005/226117166-5b4b9ebb-3866-488e-b5db-6c70be9d99e8.png)

