### PR TITLE
Feature: S3에 있는 font 파일들을 가져와 클라이언트에 응답

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,4 +21,10 @@ module.exports = {
     "react/jsx-filename-extension": ["warn", { extensions: [".js"] }],
     "no-param-reassign": 0,
   },
+  "prettier/prettier": [
+    "error",
+    {
+      endOfLine: "auto",
+    },
+  ],
 };

--- a/src/controllers/documents.controller.js
+++ b/src/controllers/documents.controller.js
@@ -32,7 +32,6 @@ exports.getDocument = async (req, res, next) => {
       "Content-Type": "application/pdf",
       "Content-Length": pdfDocument?.length,
     });
-
     res.send(pdfDocument);
   } catch (error) {
     error.message = ERRORMESSAGE.ERROR_500;

--- a/src/loaders/routers.js
+++ b/src/loaders/routers.js
@@ -1,12 +1,14 @@
 const indexRouter = require("../routes/index");
 const authRouter = require("../routes/auth");
 const usersRouter = require("../routes/users");
+const fontRouter = require("../routes/font");
 const { verifyToken } = require("../middlewares/verifyToken");
 
 const routerLoader = async (app) => {
   app.use("/", indexRouter);
   app.use("/auth", authRouter);
   app.use("/users", verifyToken, usersRouter);
+  app.use("/fonts", verifyToken, fontRouter);
 };
 
 module.exports = routerLoader;

--- a/src/models/Pdf.js
+++ b/src/models/Pdf.js
@@ -4,7 +4,11 @@ const { Schema } = mongoose;
 
 const pdfSchema = Schema(
   {
-    title: { type: String, required: true, match: /^[a-zA-Z0-9_-]+$/ },
+    title: {
+      type: String,
+      required: true,
+      match: /[^:\\\\/%*?:|\"<>]+$/,
+    },
     lastModifiedDate: { type: Date, required: true },
   },
   {

--- a/src/routes/font.js
+++ b/src/routes/font.js
@@ -1,0 +1,22 @@
+const express = require("express");
+
+const { getFontInS3 } = require("../service/s3utils");
+
+const router = express.Router();
+
+router.get("/:fontId", async (req, res, next) => {
+  try {
+    const { fontId } = req.params;
+    const font = await getFontInS3(fontId, next);
+
+    res.set("Content-Type", "font/woff2");
+    res.send(font);
+  } catch (error) {
+    error.message = ERRORMESSAGE.ERROR_500;
+    error.status = 500;
+
+    return next(error);
+  }
+});
+
+module.exports = router;

--- a/src/service/s3utils.js
+++ b/src/service/s3utils.js
@@ -83,7 +83,29 @@ const getDocumentInS3 = async (userId, documentId, next) => {
   }
 };
 
+const getFontInS3 = async (fontId, next) => {
+  try {
+    await s3ConfigSetup(next);
+
+    const fontInS3 = new GetObjectCommand({
+      Bucket: CONFIG.S3_BUCKET_NAME,
+      Key: `font/${fontId}.woff2`
+    });
+    const readableStream = await s3.send(fontInS3);
+    const arrayBuffer = await readableStream.Body.transformToByteArray();
+    const buffer = Buffer.from(arrayBuffer);
+
+    return buffer;
+  } catch (error) {
+    error.message = ERRORMESSAGE.ERROR_500;
+    error.status = 500;
+
+    return next(error);
+  }
+};
+
 module.exports = {
   uploadDocumentInS3,
   getDocumentInS3,
+  getFontInS3,
 };


### PR DESCRIPTION
### [response]포스트잇 - 글꼴 응답

### Task

- task card [링크](https://www.notion.so/vanillacoding/7ddc16eec4394b469b80ceae0d31c7e5?v=b86410c7460448958feaf40b176cd9e4&p=224491a7b11e457eb8078c0a06a3d31d&pm=s)

### Description

/fonts/:fontId
- client로부터 요청받은 url을 통해 params를 이용하여 fontId를 얻은 후에 S3 저장소에서 woff2 형식의 글꼴 파일을 받아 올 수 있는 getFontInS3 함수를 호출하여 결과값을 클라이언트에게 전달합니다.

/service/s3utils.js
```js
const readableStream = await s3.send(fontInS3);
const arrayBuffer = await readableStream.Body.transformToByteArray();
const buffer = Buffer.from(arrayBuffer);
```
- getFontInS3 함수에서 s3.send() 메서드를 사용하여 S3에서 읽을 수 있는 글꼴 파일 스트림 데이터를 얻습니다.
- readibleStream 객체의 Body 속성에 transformToByteArray() 메서드를 호출하여 스트림 데이터를 배열 버퍼로 변환합니다.
- Buffer.from() 메서드를 사용하여 배열 버퍼를 buffer라는 Node.js 버퍼 객체로 변환하여 반환합니다.
*버퍼란 데이터를 한 곳에서 다른 한 곳으로 전송하는 동안 일시적으로 그 데이터를 보관하는 임시 메모리의 영역

- 글꼴 파일 데이터가 포함된 버퍼를 클라이언트에 전달하면 CSS에 적용할 수 있는 URL을 생성할 수 있는 Blob 개체를 만들 수 있습니다.  이 URL을 CSS에서 @font-face와 함께 사용하면 웹 사이트에 글꼴을 적용할 수 있습니다.

웹 폰트 확장자 : woff2
- 웹 폰트 확장자에는 ttf, otf, eot, svg, woff, woff2가 있습니다. 그 중에서 ttf와 woff가 가장 오랫동안 사용되었으며 크롬, 사파리, 오페라, 파이어 폭스에서 지원이 됩니다.  ttf의 경우 크롬 4, 사파리 3, 오페라 10, 파이어폭스 3.5 버전 이후부터 사용이 가능하고 woff의 경우 크롬 6, 사파리 5.1, 오페라 11.1, 파이어폭스 3.5 버전 이후부터 가능합니다.
woff는 ttf의 압축 버전으로 글꼴 파일 크기를 약 20-30% 줄일 수 있어 로드 시간이 빨라지고 렌더링 성능이 향상됩니다.  
woff는 woff와 woff2로 나눌 수 있는데  woff2는 woff보다 최대 30% 더 작은 글꼴 파일 크기로 압축할 수 있습니다.
따라서, 웹 폰트 확장자로 woff2를 선택하여 S3에 폰트 파일을 저장하였습니다.

### ETC

pdf를 불러올때 한글, 숫자, 영어, 언더바, 하이픈만 있는 pdf 파일 이름을 제외한 파일명의 pdf를 불러올 수 없어 pdf 스키마에서 match: /[^:\\\\/%*?:|\"<>]+$/,로 변경하여 :, \, /,%, ?, <, >, |, *을 제외한 파일명은 가능하도록 하였습니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.
